### PR TITLE
Show spinner while loading search results

### DIFF
--- a/app/components/SearchResultsTable.js
+++ b/app/components/SearchResultsTable.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { Link } from 'react-router';
+import Loader from 'react-loader';
 
 class SearchResultsTable extends React.Component {
 
@@ -45,13 +46,16 @@ class SearchResultsTable extends React.Component {
   render() {
     return (
       <div className='container'>
-        {this.renderSearchResults()}
+        <Loader loaded={!this.props.fetchingData}>
+          {this.renderSearchResults()}
+        </Loader>
       </div>
     );
   }
 }
 
 SearchResultsTable.propTypes = {
+  fetchingData: React.PropTypes.bool,
   somethingWasSearched: React.PropTypes.bool.isRequired,
   schoolList: React.PropTypes.array.isRequired
 };

--- a/app/pages/SearchPage.js
+++ b/app/pages/SearchPage.js
@@ -10,6 +10,7 @@ import SearchResultsTable from '../components/SearchResultsTable';
 function getStateFromStores() {
   const searchResults = SearchStore.getSearchResults();
   return {
+    fetchingData: SearchStore.getFetchingData(),
     searchQuery: SearchStore.getSearchQuery(),
     schoolList: SchoolStore.getSchools(searchResults)
   };
@@ -45,6 +46,7 @@ class SearchPage extends React.Component {
           <SearchBox searchQuery={this.state.searchQuery}/>
           <div className='search-timeline'></div>
           <SearchResultsTable
+            fetchingData={this.state.fetchingData}
             somethingWasSearched={Boolean(this.state.searchQuery)}
             schoolList={this.state.schoolList}
           />

--- a/app/stores/SearchStore.js
+++ b/app/stores/SearchStore.js
@@ -5,6 +5,7 @@ import ActionTypes from '../constants/ActionTypes';
 import { EventEmitter } from 'events';
 
 const CHANGE_EVENT = 'change';
+let _fetchingData = false;
 let _searchQuery = '';
 let _searchResults = [];
 
@@ -22,6 +23,10 @@ const SearchStore = Object.assign({}, EventEmitter.prototype, {
     this.removeListener(CHANGE_EVENT, callback);
   },
 
+  getFetchingData: function() {
+    return _fetchingData;
+  },
+
   getSearchQuery: function() {
     return _searchQuery;
   },
@@ -37,11 +42,13 @@ SearchStore.dispatchToken = AppDispatcher.register(function(payload) {
   switch (action.type) {
 
     case ActionTypes.REQUEST_SEARCH:
+      _fetchingData = true;
       _searchQuery = action.query;
       SearchStore.emitChange();
       break;
 
     case ActionTypes.REQUEST_SEARCH_SUCCESS:
+      _fetchingData = false;
       _receiveSearchResults(action.response.results);
       SearchStore.emitChange();
       break;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lodash": "2.4.1",
     "react": "^0.13.3",
     "react-document-title": "^1.0.2",
+    "react-loader": "^1.2.0",
     "react-router": "^0.13.3",
     "react-slider": "~0.4.2",
     "style-loader": "^0.10.1",


### PR DESCRIPTION
Closes #33.
The only other case at the moment where a spinner would be needed is when user goes from one school page to another by directly changing the url. There is an issue #39 for that case.