### PR TITLE
Add linking to specific year in school page

### DIFF
--- a/app/components/SchoolTimelineInfo.js
+++ b/app/components/SchoolTimelineInfo.js
@@ -1,8 +1,11 @@
 'use strict';
 
+import _ from 'lodash';
 import React from 'react';
-import Timeline from './Timeline';
+import Loader from 'react-loader';
+
 import InfoRow from './InfoRow';
+import Timeline from './Timeline';
 import {processBasicInfoRow} from '../core/utils';
 
 function getInfoRow(row) {
@@ -12,14 +15,19 @@ function getInfoRow(row) {
 class SchoolTimelineInfo extends React.Component {
 
   render() {
+    const loadingTimeline = _.isEmpty(this.props.yearsActive);
     return (
       <div className='school-timeline-info-wrapper'>
         <div className='container'>
           <div className='school-timeline-info'>
-            <Timeline
-              selectedYear={this.props.selectedYear}
-              yearsActive={this.props.yearsActive}
-            />
+            <div className='school-timeline-container'>
+              <Loader color='#FFF' loaded={!loadingTimeline}>
+                <Timeline
+                  selectedYear={this.props.selectedYear}
+                  yearsActive={this.props.yearsActive}
+                />
+              </Loader>
+            </div>
             <div className='school-year-info'>
               <ol className='school-year-details-list'>
                 {processBasicInfoRow(this.props.schoolYearDetails).map(getInfoRow)}

--- a/app/pages/SchoolPage.js
+++ b/app/pages/SchoolPage.js
@@ -5,6 +5,7 @@ import DocumentTitle from 'react-document-title';
 import Loader from 'react-loader';
 
 import SchoolActionCreators from '../actions/SchoolActionCreators';
+import UIActionCreators from '../actions/UIActionCreators';
 import SchoolDetails from '../components/SchoolDetails';
 import SchoolImage from '../components/SchoolImage';
 import SchoolMap from '../components/SchoolMap';
@@ -17,8 +18,12 @@ function parseSchoolId(props) {
   return parseInt(props.params.schoolId);
 }
 
+function parseYear(props) {
+  return parseInt(props.params.year);
+}
+
 function getStateFromStores(schoolId) {
-  const selectedYear = UIStore.getSchoolTimelineYear();
+  let selectedYear = UIStore.getSchoolTimelineYear();
   return {
     fetchingData: SchoolStore.getFetchingData(),
     nameInSelectedYear: SchoolStore.getNameInSelectedYear(schoolId, selectedYear),
@@ -49,7 +54,7 @@ class SchoolPage extends React.Component {
   }
 
   componentDidMount() {
-    this.schoolDidChange(this.props.params.schoolId);
+    this.schoolDidChange(parseSchoolId(this.props), parseYear(this.props));
   }
 
   componentWillUnmount() {
@@ -59,11 +64,14 @@ class SchoolPage extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     if (parseSchoolId(nextProps) !== parseSchoolId(this.props)) {
-      this.schoolDidChange(parseSchoolId(nextProps));
+      this.schoolDidChange(parseSchoolId(nextProps), parseYear(nextProps));
     }
   }
 
-  schoolDidChange(schoolId) {
+  schoolDidChange(schoolId, year) {
+    if (year) {
+      UIActionCreators.updateYear(year);
+    }
     SchoolActionCreators.requestSchool(schoolId);
   }
 
@@ -111,7 +119,8 @@ class SchoolPage extends React.Component {
 
 SchoolPage.propTypes = {
   params: React.PropTypes.shape({
-    schoolId: React.PropTypes.string.isRequired
+    schoolId: React.PropTypes.string.isRequired,
+    year: React.PropTypes.string
   }).isRequired
 };
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -13,6 +13,7 @@ export default (
     <Route handler={SearchPage} name='search' path='/etsi-koulua' />
     <Route handler={AboutPage} name='about' path='/tietoa-palvelusta' />
     <Route handler={SchoolPage} name='school' path='/koulut/:schoolId' />
+    <Route handler={SchoolPage} name='school-with-year' path='/koulut/:schoolId/vuosi/:year' />
     <Redirect from='/' to='search' />
     <NotFoundRoute handler={NotFoundPage} />
   </Route>

--- a/app/styles/school-page.less
+++ b/app/styles/school-page.less
@@ -21,11 +21,21 @@
     .school-timeline-info {
       .row();
 
-      .timeline {
+      .school-timeline-container {
         .make-column(7, 7);
         margin-top: 50px;
         margin-bottom: 100px;
         padding-bottom: 50px;
+
+        .loader {
+          margin-top: 100px;
+        }
+      }
+
+      .timeline {
+        .horizontal-slider {
+          margin-left: (@anchor-width-percentage / 2);
+        }
         .help-text {
           position: absolute;
           top: 120px;


### PR DESCRIPTION
Makes linking to school page on a specific year possible.
The linking can be done like so:
http://localhost:3000/koulut/37/vuosi/1999

Some things to consider:
- This does not take into consideration the errors if user manually sets the url year outside the school years. Possibly in the future we should think about this but for now all year specific links should be generated by us in search results.
- I had to add a loader to timeline so the correct years will be displayed only after they are available. I had to tweak some of the timeline styles as well. 

Closes #105.