### PR TITLE
Use the new employership endpoint for search

### DIFF
--- a/app/api/SearchAPI.js
+++ b/app/api/SearchAPI.js
@@ -71,7 +71,7 @@ export default {
   },
 
   searchPrincipal(query, filters) {
-    searchRequest('principal/', query, filters, 'principals');
+    searchRequest('employership/', query, filters, 'employerships');
   },
 
   searchSchool(query, filters) {

--- a/app/api/SearchAPI.js
+++ b/app/api/SearchAPI.js
@@ -67,11 +67,19 @@ export default {
   },
 
   searchBuilding(query, filters) {
-    searchRequest('school_building/', query, filters, 'buildings');
+    const schoolFilters = {};
+    _.each(filters, function(value, key) {
+      schoolFilters[`school_${key}`] = value;
+    });
+    searchRequest('school_building/', query, schoolFilters, 'buildings');
   },
 
   searchPrincipal(query, filters) {
-    searchRequest('employership/', query, filters, 'employerships');
+    const schoolFilters = {};
+    _.each(filters, function(value, key) {
+      schoolFilters[`school_${key}`] = value;
+    });
+    searchRequest('employership/', query, schoolFilters, 'employerships');
   },
 
   searchSchool(query, filters) {

--- a/app/core/APIUtils.js
+++ b/app/core/APIUtils.js
@@ -9,11 +9,12 @@ const schoolBuilding = new Schema('schoolBuildings');
 const schoolPrincipal = new Schema('schoolPrincipals');
 const school = new Schema('schools');
 const employer = new Schema('employer');
+const employership = new Schema('employerships');
 // We need to define a searchRespone shema so normalizr finds all entities from
 // the search results.
 const schoolSearchResponse = new Schema('schoolSearchResponse');
 const buildingSearchResponse = new Schema('buildingSearchResponse');
-const principalSearchResponse = new Schema('principalSearchResponse');
+const employershipSearchResponse = new Schema('employershipSearchResponse');
 
 schoolBuilding.define({
   building: building,
@@ -28,10 +29,14 @@ employer.define({
   school: school
 });
 
+employership.define({
+  principal: principal,
+  school: school
+});
+
 principal.define({
   employers: arrayOf(employer)
 });
-
 
 school.define({
   buildings: arrayOf(schoolBuilding),
@@ -46,14 +51,14 @@ buildingSearchResponse.define({
   results: arrayOf(schoolBuilding)
 });
 
-principalSearchResponse.define({
-  results: arrayOf(principal)
+employershipSearchResponse.define({
+  results: arrayOf(employership)
 });
 
 const resultsSchemas = {
   schools: [schoolSearchResponse, 'schoolSearchResponse'],
   buildings: [buildingSearchResponse, 'buildingSearchResponse'],
-  principals: [principalSearchResponse, 'principalSearchResponse']
+  employerships: [employershipSearchResponse, 'employershipSearchResponse']
 };
 
 export function normalizeSchoolResponse(response) {

--- a/app/pages/SearchPage.js
+++ b/app/pages/SearchPage.js
@@ -8,7 +8,7 @@ import SearchControls from '../components/SearchControls';
 import SearchGridView from '../components/SearchGridView';
 import SearchTableView from '../components/SearchTableView';
 import SearchTimeline from '../components/SearchTimeline';
-import PrincipalStore from '../stores/PrincipalStore';
+import EmployershipStore from '../stores/EmployershipStore';
 import SchoolBuildingStore from '../stores/SchoolBuildingStore';
 import SchoolStore from '../stores/SchoolStore';
 import SearchStore from '../stores/SearchStore';
@@ -24,7 +24,7 @@ function getStateFromStores() {
     filtersOptions: SearchStore.getFiltersOptions(),
     nameResults: SchoolStore.getSearchDetails(searchResults.schools, searchQuery),
     nextPagesUrlDict: SearchStore.getNextPagesUrlDict(),
-    principalResults: PrincipalStore.getSearchDetails(searchResults.principals),
+    principalResults: EmployershipStore.getSearchDetails(searchResults.employerships),
     searchQuery: SearchStore.getSearchQuery(),
     selectedMapYear: SearchStore.getSelectedMapYear(),
     selectedSchoolId: SearchStore.getSelectedSchoolId(),

--- a/app/stores/EmployershipStore.js
+++ b/app/stores/EmployershipStore.js
@@ -1,0 +1,67 @@
+'use strict';
+
+import _ from 'lodash';
+
+import ActionTypes from '../constants/ActionTypes';
+import AppDispatcher from '../core/AppDispatcher';
+import {getItemByIdWrapper} from '../core/utils';
+import BaseStore from './BaseStore';
+import PrincipalStore from './PrincipalStore';
+import SchoolStore from './SchoolStore';
+
+let _employerships = {};
+
+const EmployershipStore = Object.assign({}, BaseStore, {
+  getEmployership: getItemByIdWrapper(getEmployership, _employerships),
+  getSearchDetails
+});
+
+EmployershipStore.dispatchToken = AppDispatcher.register(function(payload) {
+  const action = payload.action;
+
+  switch (action.type) {
+
+    case ActionTypes.REQUEST_SEARCH_SUCCESS:
+      _receiveEmployerships(action.response.entities.employerships);
+      EmployershipStore.emitChange();
+      break;
+
+    default:
+      // noop
+  }
+});
+
+function getEmployership(employership) {
+  return employership;
+}
+
+function getSearchDetails(employershipIds) {
+  let searchDetails = [];
+  _.each(employershipIds, function(employershipId) {
+    const employership = EmployershipStore.getEmployership(employershipId);
+    if (_.isEmpty(employership)) {
+      return;
+    }
+    const schoolId = employership.school;
+    const principalId = employership.principal;
+    const principal = PrincipalStore.getPrincipal(principalId);
+    if (_.isEmpty(principal)) {
+      return;
+    }
+    const item = _.assign({}, employership, {
+      extraInfo: principal.name,
+      type: 'principal'
+    });
+    const results = SchoolStore.getSearchDetailsForItem(schoolId, item);
+    searchDetails = searchDetails.concat(results);
+  });
+  return _.uniq(_.sortBy(searchDetails, 'id'), true, 'id');
+}
+
+function _receiveEmployerships(employerships) {
+  _.each(employerships, function(employership) {
+    _employerships[employership.id] = employership;
+  });
+}
+
+export default EmployershipStore;

--- a/app/stores/SchoolStore.js
+++ b/app/stores/SchoolStore.js
@@ -21,6 +21,7 @@ import {
 } from '../core/utils';
 import BaseStore from './BaseStore';
 import BuildingStore from './BuildingStore';
+import EmployershipStore from './EmployershipStore';
 import PrincipalStore from './PrincipalStore';
 import SchoolBuildingStore from './SchoolBuildingStore';
 import SearchStore from './SearchStore';
@@ -46,6 +47,7 @@ const SchoolStore = Object.assign({}, BaseStore, {
 SchoolStore.dispatchToken = AppDispatcher.register(function(payload) {
   AppDispatcher.waitFor([
     BuildingStore.dispatchToken,
+    EmployershipStore.dispatchToken,
     PrincipalStore.dispatchToken,
     SchoolBuildingStore.dispatchToken
   ]);

--- a/app/stores/SearchStore.js
+++ b/app/stores/SearchStore.js
@@ -45,7 +45,7 @@ let _searchQuery = '';
 let _selectedMapYear = String(DEFAULT_LAYER.beginYear);
 const _searchResultsDefaults = {
   buildings: null,
-  principals: null,
+  employerships: null,
   schools: null
 };
 let _searchResults = _resetSearchResults();


### PR DESCRIPTION
Makes the search use employership endpoint instead of the principal endpoint.
Seems like school buildings and employerships still are not filtered on the backend by other than year filters.

Closes #135.