### PR TITLE
Fix search results building

### DIFF
--- a/app/stores/SchoolStore.js
+++ b/app/stores/SchoolStore.js
@@ -279,7 +279,10 @@ function _getLatestYear(school) {
 
 function _getNamesForTimeSpan(school, beginYear, endYear) {
   return _.filter(school.names, function(name) {
-    return inBetween(name.beginYear, beginYear, endYear, true);
+    return (
+      inBetween(name.beginYear, beginYear, endYear, true) ||
+      inBetween(beginYear, name.beginYear, name.endYear, true)
+    );
   });
 }
 


### PR DESCRIPTION
In cases where the school name did not change during the
principal or building years, no results were shown.
Now results are shown if the name begin year is between
the item years or if the item begin year is between the
school name years.