### PR TITLE
Fix linking to specific year from continuum event

### DIFF
--- a/app/pages/SchoolPage.js
+++ b/app/pages/SchoolPage.js
@@ -73,8 +73,8 @@ class SchoolPage extends React.Component {
     if (year) {
       UIActionCreators.updateYear(year);
     }
-    SchoolActionCreators.requestSchool(schoolId);
     this.setState(getStateFromStores(schoolId));
+    SchoolActionCreators.requestSchool(schoolId);
   }
 
   _onChange() {


### PR DESCRIPTION
This will make the year work, but the old school info will
be visible until we get the new school fetched.