### PR TITLE
Fix issue with school building search results

### DIFF
--- a/app/stores/SchoolBuildingStore.js
+++ b/app/stores/SchoolBuildingStore.js
@@ -65,6 +65,9 @@ function getSearchDetails(schoolBuildingIds) {
 
 function _receiveSchoolBuildings(schoolBuildings) {
   _.each(schoolBuildings, function(schoolBuilding) {
+    if (_schoolBuildings[schoolBuilding.id] && _schoolBuildings[schoolBuilding.id].school) {
+      schoolBuilding.school = _schoolBuildings[schoolBuilding.id].school;
+    }
     _schoolBuildings[schoolBuilding.id] = schoolBuilding;
   });
 }


### PR DESCRIPTION
Previously schools found with address / school building
would disappear from search results if their school page
was visited. This happened because the school building
fetched from the school api endpoint did not have reference
to the school and overwrote the school building info fetched
in search results.