### PR TITLE
Add chrome to Travis test environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,13 @@ cache:
   directories:
     - node_modules
 
+addons:
+  chrome: stable
+
 install:
   - npm install
+
+script: npm run test:ci
 
 after_success:
   - npm run codecov

--- a/conf/make-karma-config.js
+++ b/conf/make-karma-config.js
@@ -7,7 +7,7 @@ module.exports = function(options) {
   var karmaConfig = {
     frameworks: ['mocha', 'chai'],
 
-    browsers: ['Chrome'],
+    browsers: ['ChromeHeadless'],
 
     // Running tests with coverage migth take some time
     browserNoActivityTimeout: 60000,

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "karma": "^0.12.31",
     "karma-chai": "^0.1.0",
     "karma-chai-sinon": "~0.1.4",
-    "karma-chrome-launcher": "0.1.8",
+    "karma-chrome-launcher": "^2.2.0",
     "karma-coverage": "^0.3.1",
     "karma-mocha": "^0.1.10",
     "karma-mocha-reporter": "^1.0.2",


### PR DESCRIPTION
Use Chromeheadless to run tests, this makes them work within Travis.